### PR TITLE
Wire sub offset to constants.py subtitle constants and increase possible bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## UNRELEASED
+
+Subtitle offset ranges are now wider (300 seconds).
+
+
 ## [2.5.0] - 2026-05-28
 
 ### Added

--- a/anki_miner/gui/constants.py
+++ b/anki_miner/gui/constants.py
@@ -34,8 +34,8 @@ SUBTITLE_FILE_FILTER = "Subtitle Files (*.ass *.srt *.ssa);;All Files (*)"
 # =============================================================================
 # SUBTITLE OFFSET RANGE
 # =============================================================================
-SUBTITLE_OFFSET_MIN = -60.0
-SUBTITLE_OFFSET_MAX = 60.0
+SUBTITLE_OFFSET_MIN = -300.0
+SUBTITLE_OFFSET_MAX = 300.0
 
 # =============================================================================
 # PATH DISPLAY

--- a/anki_miner/gui/widgets/subtitle_viewer.py
+++ b/anki_miner/gui/widgets/subtitle_viewer.py
@@ -12,6 +12,7 @@ from PyQt6.QtWidgets import (
     QVBoxLayout,
 )
 
+from anki_miner.gui.constants import SUBTITLE_OFFSET_MAX, SUBTITLE_OFFSET_MIN
 from anki_miner.gui.widgets.subtitle_player_widget import SubtitlePlayerWidget
 
 logger = logging.getLogger(__name__)
@@ -79,7 +80,7 @@ class SubtitleViewer(QDialog):
         controls_layout.addWidget(offset_label)
 
         self.offset_spinbox = QDoubleSpinBox()
-        self.offset_spinbox.setRange(-60.0, 60.0)
+        self.offset_spinbox.setRange(SUBTITLE_OFFSET_MIN, SUBTITLE_OFFSET_MAX)
         self.offset_spinbox.setSingleStep(0.1)
         self.offset_spinbox.setValue(initial_offset)
         self.offset_spinbox.setSuffix(" s")


### PR DESCRIPTION
## Summary

<!-- What does this PR do? One or two sentences. -->
Wires the subtitle_viewer spinbox range values to  SUBTITLE_OFFSET_MIN|MAX. Also adjusts these constants to 5 times the original to cover more possible use cases in subtitle delays.
## Related issue

<!-- Closes #N / Refs #N — or n/a -->

## Changes

-

## Testing

<!-- How did you verify this works? `pytest` output, manual GUI steps, etc. -->
## Checklist

- [x] Tests added or updated where applicable
- [x] `pytest` passes locally
- [x] `ruff check .` and `black --check .` pass
- [x] `mypy anki_miner` passes
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] Docs updated if behavior changed (README, ARCHITECTURE, etc.)
